### PR TITLE
added css box-sizing rules for IE logo issue

### DIFF
--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -3,6 +3,15 @@
 @import "mixins/mixins";
 @import "components/components";
 
+
+html {
+  box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
+}
+
+
 hr {
     background-color: #DEE5EB;
     border-style: none;


### PR DESCRIPTION
This should fix the logos having a ridiculous amount of bottom padding/margin/space in IE.